### PR TITLE
Release 1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-rb_register
+rb-register
 vendor/
+glide.lock
 *.out
 *.coverprofile
 *.sublime-project

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ BIN=      rb-register
 prefix?=  /usr/local
 bindir?=	$(prefix)/bin
 
-build: get
+all: vendor build
+
+build:
 	@printf "$(MKL_YELLOW)Building $(BIN)$(MKL_CLR_RESET)\n"
 	go build -ldflags "-X main.githash=`git rev-parse HEAD` -X main.version=`git describe --tags --always --dirty=-dev`" -o $(BIN)
 


### PR DESCRIPTION
- [x] Update `Makefile` with the new binary name and `glide.lock`
- [x] Allow build the project without get all dependencies