### PR TITLE
Add rb_configure_cgroups on finish

### DIFF
--- a/packaging/rpm/rb-register.spec
+++ b/packaging/rpm/rb-register.spec
@@ -11,6 +11,8 @@ BuildRequires: go rsync gcc git
 Summary: rpm used to install rb-register in a redborder ng
 Group:   Development/Libraries/Go
 
+%global debug_package %{nil}
+
 %description
 %{summary}
 

--- a/resources/bin/rb_register_finish.sh
+++ b/resources/bin/rb_register_finish.sh
@@ -95,7 +95,10 @@ if [ -f /etc/chef/role-once.json.default ]; then
     sleep 5
     rb_wakeup_chef.sh
   fi
- 
+  
+  title "Configuring cgroups (first time) please wait..."
+  rb_configure_cgroups &>/dev/null 
+  
   title "  finished rb_register_finish.sh ($(date))"
   date > /etc/redborder/sensor-installed.txt
 else


### PR DESCRIPTION
* When node is fully registered, rb_configure_cgroups should be executed in order to reassign memory 