### PR TITLE
Release 5.0.0

### DIFF
--- a/resources/bin/rb_register_finish.sh
+++ b/resources/bin/rb_register_finish.sh
@@ -97,9 +97,6 @@ if [ -f /etc/chef/role-once.json.default ]; then
     sleep 5
     rb_wakeup_chef.sh
   fi
-  
-  title "Configuring cgroups (first time) please wait..."
-  rb_configure_cgroups &>/dev/null 
  
   end_script=$(date +%s) # Save finish scrip time
   runtime=$((end_script-start_script)) # Calculate duration of script


### PR DESCRIPTION
Remove rb_configure_cgroups script call in favor of doing the same with each machine cookbook (cookbook-rb-ips, cookbook-rb-manager, ...) in #42 by @nilsver.